### PR TITLE
adding -fpic flag for linkage to required static libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(COMMAND cmake_policy)
 endif()
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(XMLRPC_C_VERSION_MAJOR "1"  CACHE STRING "Version (major) of xmlrpc-c")
 set(XMLRPC_C_VERSION_MINOR "33" CACHE STRING "Version (minor) of xmlrpc-c")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,11 +280,6 @@ set(includedir "${prefix}/include")
 
 #############
 
-if(NOT WIN32)
-  # This shell script is not useful on Windows
-  install(PROGRAMS xmlrpc-c-config DESTINATION ${_bin})
-endif()
-
 enable_testing()
 
 #add_subdirectory(test)


### PR DESCRIPTION
This flag is needed as there are required static targets which needs to be linked with shared targets.